### PR TITLE
Fixed the link in logo of Audio therapy

### DIFF
--- a/html/audioTherapy.html
+++ b/html/audioTherapy.html
@@ -20,7 +20,7 @@
   <body>
     <!-- Navbar Section -->
     <nav>
-      <a href="index.html"><img class="audio-logo" src="../logo.png" alt="Logo"/></a>
+      <a href="../index.html"><img class="audio-logo" src="../logo.png" alt="Logo"/></a>
 
       <div class="nav-links" id="navLinks">
         <i class="fa fa-times" onclick="hidemenu()"></i>


### PR DESCRIPTION
Issue #190 [SSOC 2022 participant] 
Now the link in the logo of audio therapy is fixed.
![image](https://user-images.githubusercontent.com/85568108/184120268-1193abee-f8b9-413a-90f2-91cde4c89e46.png)
