### PR TITLE
Invisible buttons on Mobile view of Reading Therapy page #279

### DIFF
--- a/css/readingTherapy.css
+++ b/css/readingTherapy.css
@@ -286,6 +286,29 @@ hr{
 .container .card .sci li a:hover {
   background-color: #54BAB9;
 }
+/*Mobile view for cards
+-----------------------------------------*/
+@media (max-width: 650px) {
+  .container .card .content {
+    transform: translateY(-30px);
+  }
+  .container .card .sci li {
+    transform: translateY(0px);
+    opacity: 1;
+  }
+}
+/* iPad & Tablet view for cards
+-----------------------------------------*/
+@media (max-width: 850px) {
+  .container .card .content {
+    transform: translateY(-30px);
+  }
+  .container .card .sci li {
+    transform: translateY(0px);
+    opacity: 1;
+  }
+}
+
 header{
    position: relative;
 }


### PR DESCRIPTION
I have added some simple CSS to make sure the buttons are displayed for the user on the Reading Therapy page :)
![image](https://user-images.githubusercontent.com/77812385/185752404-063b5c34-d3f6-456c-8b58-c7111e5ba153.png)
