### PR TITLE
Fixed the position of the overlapping button in audiobooks section

### DIFF
--- a/css/audio.css
+++ b/css/audio.css
@@ -303,6 +303,11 @@ hr {
   font-size: 14px;
 }
 
+#rew{
+  margin-bottom: 3px;
+  font-size: 14px;
+}
+
 
 .btn.btn-border::after,
 .btn.btn-border::before {

--- a/css/audio.css
+++ b/css/audio.css
@@ -298,6 +298,11 @@ hr {
   -moz-transition: ease-out 0.5s;
 }
 
+#psy{
+  margin-bottom: 3px;
+  font-size: 14px;
+}
+
 
 .btn.btn-border::after,
 .btn.btn-border::before {

--- a/html/audioTherapy.html
+++ b/html/audioTherapy.html
@@ -411,8 +411,8 @@
           <img src="https://m.media-amazon.com/images/I/41jq-ouUBkL._SL500_.jpg" alt="Rework" />
           <div class="content">
             <h3>Rework</h3>
-            <p>
-              Let's listen to the famous audiobook by David Heinemeier Hansson.
+            <p id="rew">
+              Let's listen to the famous audiobook by Jason Fried and David Heinemeier Hansson.
             </p>
             
               <a href="https://www.audible.in/pd/Rework-Audiobook/B079VF9TV6?action_code=ASSGB149080119000H&share_location=pdp&shareTest=TestShare" class="btn btn-border">Play Now</a>

--- a/html/audioTherapy.html
+++ b/html/audioTherapy.html
@@ -317,9 +317,8 @@
           <img src="https://m.media-amazon.com/images/I/51jRBz6Ug3L._SL500_.jpg" alt="The Psychology of Money" />
           <div class="content">
             <h3>The Psychology of Money</h3>
-            <p>
+            <p id="psy">
               Let's listen to the famous audiobook by Morgan Housel.
-              <br>
             </p>
             <a href="https://www.audible.in/pd/The-Psychology-of-Money-Audiobook/B08D9WJCBT?action_code=ASSGB149080119000H&share_location=pdp&shareTest=TestShare" class="btn btn-border">Play Now</a>
           </div>
@@ -413,7 +412,7 @@
           <div class="content">
             <h3>Rework</h3>
             <p>
-              Let's listen to the famous audiobook by Jason Fried and David Heinemeier Hansson.
+              Let's listen to the famous audiobook by David Heinemeier Hansson.
             </p>
             
               <a href="https://www.audible.in/pd/Rework-Audiobook/B079VF9TV6?action_code=ASSGB149080119000H&share_location=pdp&shareTest=TestShare" class="btn btn-border">Play Now</a>


### PR DESCRIPTION
Fixed the position of the overlapping "Play now" button of the "The psychology of money" card and the "rework" card in the audiobooks section.
Issue:https://github.com/Susmita-Dey/Sukoon/issues/268
Website on which I worked:https://sukoon-stress-free.netlify.app/html/audiotherapy