### PR TITLE
Fixed Overlapping Content in Reading Therapy

### DIFF
--- a/css/readingTherapy.css
+++ b/css/readingTherapy.css
@@ -65,7 +65,8 @@ nav{
 .center{
   position: absolute;
   top: 20%;
-  left: 5%;
+  left: 2%;
+  right: 2%;
   text-align: center;
   color: black;
 }
@@ -79,6 +80,7 @@ h1 {
   font-weight: 900;
 }
 #subtitle {
+
   color:black;
   background-color: burlywood;
   border: solid black 7px;
@@ -106,6 +108,11 @@ h2 {
 }
 .black-background{
   background-color: #040303;
+}
+@media screen and (max-width: 600px) {
+  .black-background{
+    margin-top: 13rem;
+  }
 }
 body{
   background-color: #040303;


### PR DESCRIPTION
Fixes Issue #247 

## Did the following changes in the mobile layout
- Fixed Overlapping Contents in the Reading Therapy Page
- The content was not aligned to center, so fixed it

![image](https://user-images.githubusercontent.com/87236576/186075378-55661ce9-2bec-4c8b-bdcf-6ca44bc89231.png)
