### PR TITLE
Fix the "X" sign on Talking Therapy page

### DIFF
--- a/css/talking.css
+++ b/css/talking.css
@@ -69,6 +69,11 @@ nav {
   z-index: 100;
 }
 
+.nav-links .fa{
+  display:none;
+
+}
+
 @media screen and (max-width: 650px) {
   .nav-links {
     display: none;


### PR DESCRIPTION
Issue #336 
I've changed the display property of icon " X ".
![image](https://user-images.githubusercontent.com/89779447/190417652-54c8deb7-2ee3-4a9e-8f91-6fa6e78a7db9.png)
