### PR TITLE
Fix Issue: #410 Make the about us section on home page responsive 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -508,7 +508,7 @@ nav .fa {
 
 .about-content p{
   max-width: 700px;
-  padding: 0 1em;
+  padding: 0 1.5em;
   font-size: 27px;
   font-family: "Montserrat";
   margin-left: 1em;

--- a/css/style.css
+++ b/css/style.css
@@ -480,43 +480,50 @@ nav .fa {
 }
 
 .about .max-width {
-  margin: auto 0 auto 85px;
-  margin-bottom: 30px;
+  /* margin: auto 0 auto 85px;
+  margin-bottom: 30px; */
   color: white;
-
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
 }
 
 .about .photo {
-  float: right;
   border: 5px solid #f9004d;
   border-radius: 10px;
-  margin-right: 10%;
+  /* margin-right: 10%; */
+  order: 2;
 }
 
-.about .about-content .text-1 {
+@media (max-width: 1050px) {
+  .about-content{
+    order: 3;
+  }
+
+  .about .photo{
+    margin-bottom: 2rem;
+  }
+}
+
+.about-content p{
+  max-width: 700px;
+  padding: 0 1em;
   font-size: 27px;
-  margin-top: 70px;
   font-family: "Montserrat";
+  margin-left: 1em;
+  margin-right: 1em;
 }
 
-.about .about-content .text-3 {
-  font-size: 27px;
-  margin: 5px 0;
-  font-family: "Montserrat";
+.text-3{
+  margin-top: 2rem;
 }
 
-.about .about-content .text-3 span,
-.about .about-content .text-1 span,
-.about .about-content .text-5 span {
+.about .about-content span,
+.about .about-content span,
+.about .about-content span {
   color: #f9004d;
   font-weight: 700;
-}
-
-.about .about-content .text-5 {
-  font-size: 27px;
-  margin-top: 40px;
-  color: #fff;
-  font-family: "Montserrat";
 }
 
 .box {
@@ -1405,39 +1412,5 @@ footer a:focus {
 @media screen and (max-width: 460px) {
   .content h1 {
     font-size: 3rem;
-  }
-}
-
-@media (max-width: 690px) {
-  .max-width {
-    padding: 0 20px;
-  }
-
-  .about .about-content .text-1 {
-    padding-top: 70%;
-  }
-}
-
-@media (max-width: 500px) {
-  .max-width {
-    padding: 0 5px;
-  }
-
-  .about .about-content .text-1 {
-    padding-top: 100px;
-  }
-}
-
-@media (max-width: 450px) {
-  .about .photo {
-    float: left;
-    margin-left: -15%;
-  }
-}
-
-@media (max-width: 400px) {
-  .about .photo {
-    float: left;
-    margin-left: -18%;
   }
 }

--- a/index.html
+++ b/index.html
@@ -110,14 +110,11 @@
   <!-- About Section -->
   <section id="about" class="about">
     <h1 data-aos="flip-right">About Us</h1>
-    <div class="max-width ">
+    <div class="max-width">
       <div data-aos="zoom-in" class="photo"><img src="./images/about.jpg" alt="" height="300px" width="330px"></div>
       <div class="about-content">
-        <div data-aos="fade-left" class="text-1"> We are a team of open source contributors <br>who have created this website Sukoon </div>
-        <div data-aos="fade-left" class="text-3"> with the aim
-          to provide a <span>one step <br>solution</span> to get relief from stress. </div>
-        <div data-aos="fade-left" class="text-5">We hope that everyone can live a <span>stress <br> free life </span>with the help of<span>
-            sukoon.</span></div>
+        <p data-aos="fade-left" class="text-1"> We are a team of open source contributors who have created this website Sukoon with the aim to provide a <span>one step solution</span> to get relief from stress. </p>
+        <p data-aos="fade-left" class="text-3">We hope that everyone can live a <span>stress free life </span>with the help of<span> sukoon.</span></p>
       </div>
     </div>
     <h3><span style="color: rgb(91, 134, 150);">MEET OUR MEMBERS</span></h3>


### PR DESCRIPTION
Closes issue #410 

- Made the about section responsive.
- Made the code more efficient with the same ui design but less lines of code.
- Removed unnecessary media queries.

Before

<img width="375" alt="Screenshot 2022-09-30 205701" src="https://user-images.githubusercontent.com/97726887/193305003-968a5bc7-fc7d-4169-a9d8-3b0c35a2682d.png">
<img width="529" alt="Screenshot 2022-09-30 205638" src="https://user-images.githubusercontent.com/97726887/193305018-33e7a5af-5ff9-428b-9a6f-f47b289a71de.png">
<img width="599" alt="Screenshot 2022-09-30 205616" src="https://user-images.githubusercontent.com/97726887/193305024-8870cc22-c27a-4d43-ae2d-e7f29ff9be64.png">


After 

<img width="887" alt="Screenshot 2022-09-30 205819" src="https://user-images.githubusercontent.com/97726887/193305063-14007005-252c-4f4f-96d2-8a24db6ae493.png">
<img width="674" alt="Screenshot 2022-09-30 205800" src="https://user-images.githubusercontent.com/97726887/193305073-87eea1d2-7647-4f28-8ba3-e02ecbb28229.png">
<img width="377" alt="Screenshot 2022-09-30 205740" src="https://user-images.githubusercontent.com/97726887/193305078-bfae99c2-185f-41dd-953d-9b7f97877efb.png">

 