### PR TITLE
Fixed buttons for 'The Psychology of Money'

### DIFF
--- a/html/readingTherapy.html
+++ b/html/readingTherapy.html
@@ -288,16 +288,6 @@
               <a href="https://www.amazon.in/Psychology-Money-Morgan-Housel/dp/9390166268/ref=sr_1_1_sspa?crid=3NGTBCRUC5JU6&keywords=psychology+of+money&qid=1659729390&sprefix=phsycology+of+mone+%2Caps%2C319&sr=8-1-spons&psc=1&spLa=ZW5jcnlwdGVkUXVhbGlmaWVyPUExVjY1MUhLNE1QSFBKJmVuY3J5cHRlZElkPUEwMzc1NDAxM05ETEZKTjBFMksySiZlbmNyeXB0ZWRBZElkPUEwMTQ1MTU4M0I4Mks1VTNZOVVXSCZ3aWRnZXROYW1lPXNwX2F0ZiZhY3Rpb249Y2xpY2tSZWRpcmVjdCZkb05vdExvZ0NsaWNrPXRydWU="
                 target="_blank" class="btn btn-border">Read</a>
             </li>
-            <li>
-              <a href="https://sukoon-stress-free.netlify.app/html/childTherapy"
-                >Child Therapy</a
-              >
-            </li>
-            <li>
-              <a href="https://sukoon-stress-free.netlify.app/html/spiritualTherapy"
-                >Spiritual Therapy</a
-              >
-            </li>
           </ul>
         </div>
         <div class="card">


### PR DESCRIPTION
Fixes #537

Removed buttons `Child Therapy` and `Spiritual Therapy` and centered `Read` button for **The Psychology of Money**

Preview:

![fix-issue-537](https://user-images.githubusercontent.com/31766648/195980730-fab6631c-d0dd-4e4b-b874-b183cc85fbea.png)
