### PR TITLE
docs: Fix Links in CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -118,7 +118,7 @@ version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+enforcement ladder](https://github.com/mozilla/inclusion/blob/master/code-of-conduct-enforcement/consequence-ladder.md).
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@
  ## Quicklinks 
   
  * [Code of Conduct](#code-of-conduct)
- * [Getting Started](#getting-started)
+ * [Getting Started](#gettingstarted)
  * [Issues](#issues)
- * [Pull Requests](#pull-requests)
+ * [Pull Requests](#pullrequests)
 
   
  ## Code of Conduct


### PR DESCRIPTION
The quicklinks and Mozilla enforcement ladder links are updated.
Close #545 