### PR TITLE
[FIX] ChildTherapy Video Section

### DIFF
--- a/css/childTherapy.css
+++ b/css/childTherapy.css
@@ -369,11 +369,11 @@ hr {
   box-sizing: border-box;
     width: 38%;
     padding: 5px;
-    margin-left: 8.5%;
+    margin-left: 6.5%;
     margin-bottom: 5px;
   }
   iframe{
-    padding:10px;
+    padding:20px;
   }
   iframe:hover{
     border:  1.5px cyan solid ;

--- a/html/childTherapy.html
+++ b/html/childTherapy.html
@@ -117,7 +117,7 @@
     <h1 class="section-headings">VIDEOS</h1>
     <div class="collection">
       <div class="video">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/myz0kxHLnLU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/_NTfTd4HCRo?si=qeEoiQqz7HKqiZ1T" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
       <div class="video">
         <iframe width="560" height="315" src="https://www.youtube.com/embed/zs21cKJs87E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -132,7 +132,7 @@
         <iframe width="560" height="315" src="https://www.youtube.com/embed/gB12TV38QBo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
       <div class="video">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/GZECezeVg08" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/cmCtTFRLaks?si=E0cL60acdnPoVnwi" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## ISSUES I Found in Video Section of Child Therapy Page
- Some of the video resources were unavailable 
- High left-margin which results in appropriate position (Off-Centered)
-  Padding between iframes is too small

## Preview of ISSUES
![image](https://github.com/Susmita-Dey/Sukoon/assets/61287791/e03db969-3322-4318-8dc1-b4ec47515504)
![image](https://github.com/Susmita-Dey/Sukoon/assets/61287791/db1e71c6-8e55-4b28-99d0-34539f0e887b)

## What I have fixed
- Added new video resources 
- Changed some CSS value to center the Video Section and Iframe View Design

## Preview of Solution

![image](https://github.com/Susmita-Dey/Sukoon/assets/61287791/d2df2a25-dfe2-4403-adc3-060ffbff1cd3)
![image](https://github.com/Susmita-Dey/Sukoon/assets/61287791/bf4e9030-5e9e-4e36-94fd-ea82152af002)




