### PR TITLE
Hide the 'Show Password' button on the right side of the password input box in different browsers

### DIFF
--- a/html/login.html
+++ b/html/login.html
@@ -8,6 +8,11 @@
     <link rel="stylesheet" href="css/login.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/all.min.css">
     <title>Sukoon - Login</title>
+    <style>
+      input[type="password"]::-ms-reveal{
+        display:none
+      }
+    </style>
   </head>
   <body onload="myfunction()">
     <div id="load">

--- a/html/login.html
+++ b/html/login.html
@@ -9,9 +9,12 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/all.min.css">
     <title>Sukoon - Login</title>
     <style>
-      input[type="password"]::-ms-reveal{
-        display:none
+      input[type="password"]::-webkit-credentials-auto-fill-button,
+      input[type="password"]::-webkit-contacts-auto-fill-button,
+      input[type="password"]::-ms-reveal {
+        display: none;
       }
+
     </style>
   </head>
   <body onload="myfunction()">


### PR DESCRIPTION
I fixed the bug described in #620  by hiding the "Show Password" button on the right side of the password input box in different browsers
