### PR TITLE
Fixed - Close the  navbar drawer (in mobile)  when a link inside it is clicked

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -59,3 +59,8 @@ const backTop = () => {
 
 backTopElement.addEventListener("click", backTop);
 ham.addEventListener("click", toggleMenu);
+
+// Close the drawer when a link inside it is clicked
+document.querySelectorAll('.menu a').forEach(link => {
+  link.addEventListener('click',toggleMenu);
+});


### PR DESCRIPTION
## Describe your changes
Fixed - Close the  navbar drawer (in mobile)  when a link inside it is clicked.
just added an click eventListner on <a> tags inside menu with toggleMenu function
## Screenshots - If Any (Optional)

## Link to issue
<!-- Example: Closes #31 -->
Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [X] I ran the app and tested it locally to verify that it works as expected.
- [X] I have checked my code with an automatic accessibility tool and it shows no errors.

## Additional Information (Optional)
Any additional information that you want to give us.
