### PR TITLE
Adjust image styling to use 'cover' fit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -573,6 +573,8 @@ nav .fa {
   height: 200px;
   width: 200px;
   border-radius: 50%;
+  object-fit: cover;
+  /* add the cover fit because  img not fit in the card  */
 }
 
 .card img:hover {


### PR DESCRIPTION
Fix: Adjust image styling to use 'cover' fit property for proper display within cards.
- Images now properly fit the card dimensions without overflow or distortion.
- Ensured consistent appearance across all cards.

## Describe your changes
Fix: Resolve image fitting issue on cards by implementing 'cover' fit property.
- Applied CSS 'object-fit: cover' to ensure images maintain aspect ratio and fill the card space appropriately.


## Screenshots - If Any (Optional)
<img width="1680" alt="Screenshot 2024-06-09 at 1 15 10 AM" src="https://github.com/Susmita-Dey/Sukoon/assets/106014185/ca36925c-56e9-4ef9-855f-9ee4871f179b">
## After fix 
<img width="1680" alt="Screenshot 2024-06-09 at 1 15 25 AM" src="https://github.com/Susmita-Dey/Sukoon/assets/106014185/5ec001cf-f2c5-44bc-b080-f4100b0f3c8d">

## Link to issue
<!-- Example: Closes #31 -->
Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [ ] I ran the app and tested it locally to verify that it works as expected.
- [ ] I have checked my code with an automatic accessibility tool and it shows no errors.

## Additional Information (Optional)
Any additional information that you want to give us.
