### PR TITLE
Fixed issue with 'About Us' link in all relevant pages - issue #647

### DIFF
--- a/html/audioTherapy.html
+++ b/html/audioTherapy.html
@@ -551,7 +551,7 @@
       <div class="col">
         <h3>HOME</h3>
         <ul>
-          <li><a href="#about">About Us</a></li>
+          <li><a href="../#about">About Us</a></li>
           <li>
             <a href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md">Code Of Conduct</a>
           </li>

--- a/html/childTherapy.html
+++ b/html/childTherapy.html
@@ -185,7 +185,7 @@
         <div class="col">
           <h3>HOME</h3>
           <ul>
-            <li><a href="#about">About Us</a></li>
+            <li><a href="../#about">About Us</a></li>
             <li>
               <a href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md">Code Of Conduct</a>
             </li>

--- a/html/laughTherapy.html
+++ b/html/laughTherapy.html
@@ -324,7 +324,7 @@
           <div class="col">
             <h3>HOME</h3>
             <ul>
-              <li><a href="#about">About Us</a></li>
+              <li><a href="../#about">About Us</a></li>
               <li><a href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md">Code Of Conduct</a></li>
               <li><a href="https://github.com/Susmita-Dey/Sukoon">Contribute</a></li>
               <li><a href="https://www.buymeacoffee.com/susmitadey">Donate</a></li>

--- a/html/readingTherapy.html
+++ b/html/readingTherapy.html
@@ -454,7 +454,7 @@
             <h3>HOME</h3>
             <ul>
 
-              <li><a href="#about">About Us</a></li>
+              <li><a href="../#about">About Us</a></li>
               <li>
                 <a href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md">Code Of Conduct</a>
               </li>

--- a/html/specialTherapy.html
+++ b/html/specialTherapy.html
@@ -191,7 +191,7 @@
           <div class="col">
             <h3>HOME</h3>
             <ul>
-              <li><a href="#about">About Us</a></li>
+              <li><a href="../#about">About Us</a></li>
               <li>
                 <a
                   href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md"

--- a/html/spirituality.html
+++ b/html/spirituality.html
@@ -192,7 +192,7 @@ VENUE : ONLINE ZOOM</b> </p>
         <div class="col">
           <h3>HOME</h3>
           <ul>
-            <li><a href="#about">About Us</a></li>
+            <li><a href="../#about">About Us</a></li>
             <li>
               <a
                 href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md"

--- a/html/talkingTherapy.html
+++ b/html/talkingTherapy.html
@@ -254,7 +254,7 @@
       <div class="col">
         <h3>HOME</h3>
         <ul>
-          <li><a href="#about">About Us</a></li>
+          <li><a href="../#about">About Us</a></li>
           <li>
             <a
               href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md"

--- a/html/yogatherapy.html
+++ b/html/yogatherapy.html
@@ -355,7 +355,7 @@
         <div class="col">
           <h3>HOME</h3>
           <ul>
-            <li><a href="#about">About Us</a></li>
+            <li><a href="../#about">About Us</a></li>
             <li>
               <a
                 href="https://github.com/Susmita-Dey/Sukoon/blob/main/CODE_OF_CONDUCT.md"


### PR DESCRIPTION
## Describe your changes
About Us anchor was in main index.html page and not in the individual services page.
Fixed it by using relative url '../#about'
The same issue was also present in other services pages:
childTherapy, laughTherapy, readingTherapy, specialTherapy, spirituality, talkingTherapy, yogatherapy

## Link to issue
Closes #647 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [ ] I have checked my code with an automatic accessibility tool and it shows no errors.
